### PR TITLE
fix: positioning on vertical displays

### DIFF
--- a/menubar.js
+++ b/menubar.js
@@ -1,9 +1,9 @@
 const path = require('path')
 const Positioner = require('./positioner')
 const merge = require('lodash.merge')
-const {EventEmitter} = require('events')
+const { EventEmitter } = require('events')
 const electron = require('electron')
-const {app, Tray, BrowserWindow} = electron
+const { app, Tray, BrowserWindow } = electron
 
 const defaults = {
   preloadWindow: false,

--- a/positioner.js
+++ b/positioner.js
@@ -194,13 +194,13 @@ class Positioner {
    * @return {string} - the position of the taskbar (top|right|bottom|left)
    */
   static getTaskbarPosition () {
-    const display = getDisplay()
+    const { bounds, workArea } = getDisplay()
 
-    if (display.workArea.y > 0) {
+    if (workArea.y > bounds.y) {
       return 'top'
-    } else if (display.workArea.x > 0) {
+    } else if (workArea.x > bounds.x) {
       return 'left'
-    } else if (display.workArea.width === display.bounds.width) {
+    } else if (workArea.width === bounds.width) {
       return 'bottom'
     }
 


### PR DESCRIPTION
Positioning when a multiple screen setup was in place where two screens where disposed vertically was wrong.

The problem was that we're just comparing the values to zero, when it might not happen that way if we get negative values.